### PR TITLE
add default package to packages attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,5 +7,5 @@ default['htpasswd']['path']        = ::File.join(node['htpasswd']['install_dir']
 
 default['htpasswd']['packages'] = value_for_platform_family(
   ['rhel', 'fedora', 'suse'] => ['httpd-tools'],
-  'debian' => ['apache2-utils']
+  ['default', 'debian'] => ['apache2-utils']
 )


### PR DESCRIPTION
When running chefspec testing on ubuntu, there was no attribute existing for the default packages attribute, this lead to the following error:
```
NoMethodError:
       undefined method `each' for nil:NilClass
     # /tmp/d20151013-20375-1tqy8ps/cookbooks/htpasswd/recipes/packages.rb:1:in `from_file'
     # /tmp/d20151013-20375-1tqy8ps/cookbooks/htpasswd/recipes/default.rb:21:in `from_file'
```

I simply added default to the second config line, this works properly, considering on ubuntu and debian, the `apache2-utils` package is used.