### PR TITLE
Switch from python to poise-python

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ version '0.2.5'
   supports os
 end
 
-depends 'python'
+depends 'poise-python'
 
 source_url 'https://github.com/redguide/htpasswd' if respond_to?(:source_url)
 issues_url 'https://github.com/redguide/htpasswd/issues' if respond_to?(:issues_url)

--- a/recipes/python.rb
+++ b/recipes/python.rb
@@ -18,4 +18,4 @@
 # limitations under the License.
 #
 
-python_pip 'htpasswd-cli'
+python_package 'htpasswd-cli'


### PR DESCRIPTION
The `python` cookbook was deprecated in favor of `poise-python`.  Due to this, the `python` cookbook is no longer being updated and causes deprecation warnings in a chef run.