### PR TITLE
support for 'plaintext' type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ end
 group :integration do
   gem 'kitchen-vagrant'
   gem 'test-kitchen'
+  gem 'kitchen-dokken'
 end

--- a/README.md
+++ b/README.md
@@ -42,4 +42,11 @@ htpasswd "/etc/nginx/htpassword" do
   password "bar"
   type "sha1"
 end
+
+# add user "foo" with encrypted password using plaintext as the type.
+htpasswd "/etc/nginx/htpassword" do
+  user "foo"
+  password "$apr1$H5Z8CUB.$L3wyxUF1ZDd.oZFlTkJ4X."
+  type "plaintext"
+end
 ```

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -73,14 +73,16 @@ def user_exists?
 end
 
 def user_set?
-  if new_resource.type == 'plaintext'
-    if new_resource.password == user_entry.digest
-      true
+  unless user_entry.nil?
+    if new_resource.type == 'plaintext'
+      if new_resource.password == user_entry.digest
+        true
+      else
+        false
+      end
     else
-      false
+      user_entry.authenticated?(new_resource.password)
     end
-  else
-    user_entry.authenticated?(new_resource.password) unless user_entry.nil?
   end
 end
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -73,7 +73,15 @@ def user_exists?
 end
 
 def user_set?
-  user_entry.authenticated?(new_resource.password) unless user_entry.nil?
+  if new_resource.type == 'plaintext'
+    if new_resource.password == user_entry.digest
+      true
+    else
+      false
+    end
+  else
+    user_entry.authenticated?(new_resource.password) unless user_entry.nil?
+  end
 end
 
 #   cmd = "htpasswd -v #{file} #{user} #{password}"

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -73,16 +73,15 @@ def user_exists?
 end
 
 def user_set?
-  unless user_entry.nil?
-    if new_resource.type == 'plaintext'
-      if new_resource.password == user_entry.digest
-        true
-      else
-        false
-      end
+  return false if user_entry.nil?
+  if new_resource.type == 'plaintext'
+    if new_resource.password == user_entry.digest
+      true
     else
-      user_entry.authenticated?(new_resource.password)
+      false
     end
+  else
+    user_entry.authenticated?(new_resource.password)
   end
 end
 

--- a/test/cookbooks/htpasswd_test/recipes/default.rb
+++ b/test/cookbooks/htpasswd_test/recipes/default.rb
@@ -17,6 +17,13 @@ htpasswd file do
 end
 
 htpasswd file do
+  user 'jane'
+  password '$apr1$PsW9V1Ij$lDqu.ixfvbG5hRN27c5Xn/'
+  type 'plaintext'
+end
+
+
+htpasswd file do
   user 'admin'
   action :delete
 end

--- a/test/cookbooks/htpasswd_test/recipes/default.rb
+++ b/test/cookbooks/htpasswd_test/recipes/default.rb
@@ -22,7 +22,6 @@ htpasswd file do
   type 'plaintext'
 end
 
-
 htpasswd file do
   user 'admin'
   action :delete


### PR DESCRIPTION
Adding a support for 'plaintext' as a encryption type.
This will enable users to create htpasswd entry from plaintext (e.g. strings already encrypted) and check if the existing entry is matching with the new resource attribute.
